### PR TITLE
Allow other text in the caption of the image + custom emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "dotenv": "^16.4.7",
+    "emoji-regex": "^10.4.0",
     "node-json-db": "^2.3.1",
     "node-telegram-bot-api": "^0.66.0",
     "sharp": "^0.33.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
+      emoji-regex:
+        specifier: ^10.4.0
+        version: 10.4.0
       node-json-db:
         specifier: ^2.3.1
         version: 2.3.1
@@ -680,6 +683,9 @@ packages:
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  emoji-regex@10.4.0:
+    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2228,6 +2234,8 @@ snapshots:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  emoji-regex@10.4.0: {}
 
   end-of-stream@1.4.4:
     dependencies:

--- a/src/controller/bot.ts
+++ b/src/controller/bot.ts
@@ -64,7 +64,7 @@ export const createStickerController = async (
 
   const packName = stickerPackName(chatId);
 
-  if (caption.startsWith("#stiku")) {
+  if (caption.indexOf("#stiku") >= 0) {
     const fileId = msg.photo?.pop()?.file_id || msg.sticker?.file_id;
     if (!fileId) return;
 

--- a/src/controller/bot.ts
+++ b/src/controller/bot.ts
@@ -1,5 +1,5 @@
 import TelegramBot from "node-telegram-bot-api";
-import { isGroup, isUserAdmin, stickerPackName } from "../utils/utils";
+import {getEmoji, isGroup, isUserAdmin, stickerPackName} from "../utils/utils";
 import { createSticker, createStickerPack } from "../services/bot";
 
 export const createPackController = async (
@@ -52,7 +52,7 @@ export const createStickerController = async (
 ) => {
   const chatId = msg.chat.id;
   const userId = msg.from?.id;
-  const caption = msg.caption?.trim() ?? "";
+  const caption = msg.caption?.split(" ") ?? [];
 
   // User ID must be available
   if (!userId) return;
@@ -69,7 +69,7 @@ export const createStickerController = async (
     if (!fileId) return;
 
     try {
-      createSticker(bot, fileId, packName, chatId);
+      await createSticker(bot, fileId, packName, chatId, getEmoji(caption) ?? "🖼️");
       await bot.sendMessage(chatId, "✅ Sticker added to the pack!");
       const newSticker = (await bot.getStickerSet(packName)).stickers.at(-1);
       if (newSticker) {

--- a/src/services/bot.ts
+++ b/src/services/bot.ts
@@ -7,7 +7,8 @@ export const createSticker = async (
   bot: TelegramBot,
   fileId: string,
   pack: string,
-  chatID: number
+  chatID: number,
+  emoji: string,
 ) => {
   const stickerPath = await processImage(fileId, bot);
   const trimmedChatId = trimChatID(chatID);
@@ -16,7 +17,7 @@ export const createSticker = async (
     owner,
     pack,
     fs.createReadStream(stickerPath),
-    "🔥",
+    emoji,
     "png_sticker"
   );
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -47,6 +47,11 @@ export const processImage = async (
   return filePath;
 };
 
+export const getEmoji = (caption: string[]): string|undefined => {
+  const emojis: string[] = caption.filter((word) => /[\p{Emoji}\u200d]+/gu.test(word)).slice(0, 1);
+  return (emojis.length >= 1) ? emojis.join("") : undefined
+}
+
 /**
  * Generates sticker pack name based on group ID
  *

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,6 +2,7 @@ import TelegramBot from "node-telegram-bot-api";
 import axios from "axios";
 import sharp from "sharp";
 import { BOT_NAME } from "./globals";
+import "emoji-regex";
 
 /**
  * Check if user is admin in selected group
@@ -48,7 +49,10 @@ export const processImage = async (
 };
 
 export const getEmoji = (caption: string[]): string|undefined => {
-  const emojis: string[] = caption.filter((word) => /[\p{Emoji}\u200d]+/gu.test(word)).slice(0, 1);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const emojiRegex = require('emoji-regex');
+  const regex = emojiRegex();
+  const emojis: string[] = caption.filter((word) => regex.test(word)).slice(0, 1);
   return (emojis.length >= 1) ? emojis.join("") : undefined
 }
 


### PR DESCRIPTION
Due to user feedback, allow other text to be in the image caption before the #stiku tag.