### PR TITLE
feat: Add support for color emoji in text stickers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN apk add --update --no-cache build-base \
 	fontconfig \
 	freetype \
 	ttf-freefont \
-	font-roboto \
-	font-noto-emoji
+#	font-noto-emoji \
+	font-roboto
+
+ADD https://github.com/samuelngs/apple-emoji-linux/releases/latest/download/AppleColorEmoji.ttf /usr/share/fonts/AppleColorEmoji.ttf
+RUN fc-cache -f -v
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ You can also use Docker to run the application, build with `docker compose build
 
 If your system is not directly supported by [node-canvas](https://github.com/Automattic/node-canvas), check what system packages you have to install before running this app.
 
+## FAQ
+
+- _Why are emojis not rendered? / Why are emojis rendered using wrong font?_
+  - `node-canvas` uses system emoji font to render emojis. Use Docker if you need other emoji version.
+
 ## Contributing
 
 Feel free to submit PR:s to this repo. All code should be formatted with `pnpm format`.

--- a/src/services/chatBubble.ts
+++ b/src/services/chatBubble.ts
@@ -11,6 +11,24 @@ import { getTime } from "../utils/utils";
 import { dataUriToBuffer } from "data-uri-to-buffer";
 import sharp from "sharp";
 
+type CustomContext = CanvasRenderingContext2D & { textDrawingMode: string };
+
+class EmojiText extends FabricText {
+  _render(ctx: CustomContext) {
+    ctx.textDrawingMode = "glyph";
+    super._render(ctx);
+    ctx.textDrawingMode = "path";
+  }
+}
+
+class EmojiTextBox extends Textbox {
+  _render(ctx: CustomContext) {
+    ctx.textDrawingMode = "glyph";
+    super._render(ctx);
+    ctx.textDrawingMode = "path";
+  }
+}
+
 export const createChatBubble = async (
   text: string,
   name: string,
@@ -26,14 +44,14 @@ export const createChatBubble = async (
     ? getAccent(profileTheme.accent)
     : randomAccent();
 
-  const nameBox = new FabricText(name, {
+  const nameBox = new EmojiText(name, {
     fontSize: 18,
     fill: accent,
     fontFamily: fontFamily,
     fontStyle: "bold",
   });
 
-  const adminBox = new FabricText(adminTitle ?? "", {
+  const adminBox = new EmojiText(adminTitle ?? "", {
     fontSize: 18,
     textAlign: "right",
     fill: "grey",
@@ -45,13 +63,12 @@ export const createChatBubble = async (
     text.length > 50 ? 512 : Math.max(300, titleBarWidth + textBoxStart);
   const boxWidth = fullWidth - textBoxStart - padding;
 
-  const box = new Textbox(text, {
+  const box = new EmojiTextBox(text, {
     width: boxWidth - 3 * padding,
     fontSize: 18,
     fill: "white",
     backgroundColor: "#182533",
     padding: 10,
-    cornerRadius: 15,
     fontFamily: fontFamily,
   });
 


### PR DESCRIPTION
Emojis are rendered using system emoji font. Docker version uses Apple emojis like Telegram clients.
![image](https://github.com/user-attachments/assets/6cf966cd-2eeb-44cf-a4e9-fa126b105dce)

*Closes #6*