### PR TITLE
chore: Improve error reporting & clarify authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .env
 node_modules/
 dist/
+coverage
 
 sticker.webp
 sticker.png
 database.json
 
 *.zip
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This bot can be used to create collaborative sticker packs for Telegram groups. 
 _This part is subject to change_
 
 1. Group admin/owner adds the bot into the group, and sends command `/createPack`
+   - Before this, user who wishes to create pack has to authorize the bot by sending `/start` to the bot with direct message (not in a group).
    - This creates the initial Sticker pack with Hello World sticker
 2. After the pack has been created, all images sent to the group with `#stiku (<emojis>)` as the caption are added to the pack
    - Replying to existing image/sticker with `#stiku (<emojis>)` also adds it to the pack

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import {
   createStickerController,
   textStickerController,
 } from "./controller/bot";
-import { isGroup } from "./utils/utils";
+import { isGroup, isPrivate } from "./utils/utils";
 
 const bot = new Bot(TOKEN);
 
@@ -16,6 +16,14 @@ bot.command("createPack", async (ctx) => {
 bot.command("hello", (ctx) => {
   ctx.api.getUpdates({ offset: -1 });
   ctx.reply("Hello there!");
+});
+
+bot.command("start", (ctx) => {
+  if (ctx.message && isPrivate(ctx.message)) {
+    ctx.reply(
+      "Bot activated! Use /createPack in any group you have admin rights to create a new sticker pack.",
+    );
+  }
 });
 
 bot.command("groupID", (ctx) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -83,6 +83,10 @@ export const isGroup = (msg: Message): boolean => {
   return msg.chat.type == "group" || msg.chat.type === "supergroup";
 };
 
+export const isPrivate = (msg: Message): boolean => {
+  return msg.chat.type === "private";
+};
+
 /**
  * Parse Telegram message timestamp to HH:MM format
  *


### PR DESCRIPTION
- Bot should now send more accurate error messages in common situations (bot not authorized, pack not created)
- Clarified that the bot has to be authorized with `/start` before it can be used